### PR TITLE
Relay Test App Updates -  BCLOUD-8742  - BCLOUD-8526 - Versioning and…

### DIFF
--- a/RelayTestApp/src/App.css
+++ b/RelayTestApp/src/App.css
@@ -21,6 +21,21 @@ small {
   color: #61dafb;
 }
 
+.VersionOverlay {
+    position: fixed;
+    bottom: 8px;
+    left: 8px;
+    background-color: rgba(0, 0, 0, 0.45);
+    padding: 6px 10px;
+    border-radius: 4px;
+    font-size: 9pt;
+    text-align: left;
+    line-height: 1.6;
+    pointer-events: none;
+    z-index: 1000;
+    color: rgba(255, 255, 255, 0.75);
+}
+
 .colorBtn {
     -moz-user-select: -moz-none;
     -khtml-user-select: none;
@@ -92,6 +107,13 @@ small {
 
 .Button:active {
     background-color: #789;
+}
+
+.Splotch {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    position: relative;
 }
 
 .Shockwave {

--- a/RelayTestApp/src/App.js
+++ b/RelayTestApp/src/App.js
@@ -49,6 +49,7 @@ class App extends Component {
       gameStartTime: null,
       splotchDurationSec: -1,
       round: 0,
+      lobbyResetting: false,
       loadingStatus: '',
       relayOptions: {
         reliable: false,
@@ -58,6 +59,7 @@ class App extends Component {
 
     this.state = state
 
+    console.log('Checking if reconnect is possible . . .')
     if (this.bc.canReconnect()) {
       console.log('Attempting reconnect . . .')
       this.bc.reconnect(reconnectResponse => {
@@ -356,6 +358,8 @@ class App extends Component {
 
       if (this.state.screen === 'joiningLobby') {
         this.setState({ screen: 'lobby' })
+      } else if (this.state.lobbyResetting) {
+        this.setState({ lobbyResetting: false })
       }
     }
 
@@ -372,6 +376,7 @@ class App extends Component {
     } else if (result.operation === 'MEMBER_LEFT') {
       this.setState({ loadingStatus: 'A player left the lobby.' })
     } else if (result.operation === 'STARTING') {
+      loadingTimerStart = Date.now()
       presentWhileStarted = true
       this.updatePresentSinceStart()
       this.setState({
@@ -629,8 +634,13 @@ class App extends Component {
         clearTimeout(autoEndTimer)
         autoEndTimer = null
       }
+      this.bc.relay.deregisterRelayCallback()
+      this.bc.relay.deregisterSystemCallback()
+      this.bc.relay.disconnect()
+      loadingTimerStart = null
       let state = this.state
       state.screen = 'lobby'
+      state.lobbyResetting = true
       state.user.isReady = false
       state.user.presentSinceStart = false
       state.splotches = []
@@ -989,6 +999,7 @@ class App extends Component {
               user={this.state.user}
               lobby={this.state.lobby}
               teams={this.state.teams}
+              lobbyResetting={this.state.lobbyResetting}
               onBack={this.onGameScreenClose.bind(this)}
               onColorChanged={this.onColorChanged.bind(this)}
               onTeamChanged={this.onTeamChanged.bind(this)}

--- a/RelayTestApp/src/App.js
+++ b/RelayTestApp/src/App.js
@@ -1,889 +1,1058 @@
 import React, { Component } from 'react'
-import './App.css';
-import ids from './ids'; // CREATE ids.js AND EXPORT appId, appSecret (and optionally url)
+import './App.css'
+import ids from './ids' // CREATE ids.js AND EXPORT appId, appSecret (and optionally url)
 
 // Screens
-import LoginScreen from './LoginScreen';
-import LoadingScreen from './LoadingScreen';
-import MainMenuScreen from './MainMenuScreen';
-import LobbyScreen from './LobbyScreen';
-import GameScreen from './GameScreen';
+import LoginScreen from './LoginScreen'
+import LoadingScreen from './LoadingScreen'
+import MainMenuScreen from './MainMenuScreen'
+import LobbyScreen from './LobbyScreen'
+import GameScreen from './GameScreen'
 
 var Buffer = require('buffer/').Buffer // note: the trailing slash is important!
 
-let brainCloud = require("braincloud")
+let brainCloud = require('braincloud')
 let colors = require('./Colors').colors
 
-let presentWhileStarted = false;
-let server = null;
-let showJoinButton = false;
+const APP_VERSION = '1.0'
+const MATCH_DURATION_SEC = 90
+const NUM_ARROW_IMAGES = 8
 
-export function getShowJoinButton(){
-    return showJoinButton
+let presentWhileStarted = false
+let server = null
+let showJoinButton = false
+let autoEndTimer = null
+let loadingTimerStart = null // When the user first clicked Play (drives the elapsed timer)
+
+export function getShowJoinButton () {
+  return showJoinButton
 }
 
-class App extends Component
-{
-    constructor()
-    {
-        super()
+class App extends Component {
+  constructor () {
+    super()
 
-        this.shockwaveNextId = 0
-        this.initBC()
+    this.initBC()
+    this.shockwaveNextId = 0
 
-        let state = {
-            screen: "reconnecting",
-            storedProfileID: null,
-            user: null,             
-            appLobbies: [],         
-            lobby: null,            
-            disbandOnStart: false,  
-            teams: [],              
-            server: null,           
-            shockwaves: [],         
-            relayOptions: {
-                reliable: false,
-                ordered: true
-            }
+    let state = {
+      screen: 'reconnecting',
+      storedProfileID: null,
+      shockwaves: [],
+      user: null,
+      appLobbies: [],
+      lobby: null,
+      disbandOnStart: false,
+      teams: [],
+      server: null,
+      splotches: [],
+      gameStartTime: null,
+      splotchDurationSec: -1,
+      round: 0,
+      loadingStatus: '',
+      relayOptions: {
+        reliable: false,
+        ordered: true
+      }
+    }
+
+    this.state = state
+
+    if (this.bc.canReconnect()) {
+      console.log('Attempting reconnect . . .')
+      this.bc.reconnect(reconnectResponse => {
+        if (reconnectResponse.status === 200) {
+          console.log('Reconnect success')
+          if (reconnectResponse.data.playerName) {
+            this.username = reconnectResponse.data.playerName
+            this.onLoggedIn(reconnectResponse)
+          } else {
+            this.dieWithMessage('No player name')
+          }
+        } else {
+          console.log(
+            'Reconnect failed, displaying login screen. Error: ' +
+              reconnectResponse
+          )
+          this.initBC()
+          this.setState(this.makeDefaultState())
         }
-
-        this.state = state
-
-        console.log("Checking if reconnect is possible . . .")
-        if (this.bc.canReconnect()) {
-            console.log("Attempting reconnect . . .")
-            this.bc.reconnect(reconnectResponse => {
-                if (reconnectResponse.status === 200) {
-                    console.log("Reconnect success")
-                    if (reconnectResponse.data.playerName) {
-
-                        // Connect to braincloud
-                        this.username = reconnectResponse.data.playerName
-
-                        this.onLoggedIn(reconnectResponse)
-                    }
-                    else {
-                        // TODO:  should be impossible since universal authentication is only option for new users
-                        this.dieWithMessage("No player name")
-                    }
-                }
-                else {
-                    console.log("Reconnect failed, displaying login screen. Error: " + reconnectResponse)
-                    // Initialize BC libs and start over
-                    this.initBC()
-
-                    // Go back to default login state
-                    this.setState(this.makeDefaultState())
-                }
-            })
-        }
-        else {
-            console.log("No saved profile ID. Welcome new user")
-            this.state = this.makeDefaultState()
-        }
+      })
+    } else {
+      console.log('No saved profile ID. Welcome new user')
+      this.state = this.makeDefaultState()
     }
+  }
 
-    componentDidMount()
-    {
-        window.addEventListener("beforeunload", (ev) => {
-            this.bc.logoutOnApplicationClose(false);
+  componentDidMount () {
+    window.addEventListener('beforeunload', ev => {
+      this.bc.logoutOnApplicationClose(false)
+      return
+    })
+  }
 
-            return;
-        });
+  // Initialize brainCloud library
+  initBC () {
+    this.bc = new brainCloud.BrainCloudWrapper('relayservertest')
+    this.bc.initialize(ids.appId, ids.appSecret, '5.9.0')
+    if (ids.url) this.bc.brainCloudClient.setServerUrl(ids.url)
+    this.bc.brainCloudClient.enableLogging(true)
+  }
+
+  // Create default blank state for the app
+  makeDefaultState () {
+    return {
+      screen: 'login',
+      storedProfileID: null,
+      shockwaves: [], // Players' created shockwaves
+      user: null,
+      appLobbies: [],
+      lobby: null,
+      disbandOnStart: false,
+      teams: [],
+      server: null,
+      splotches: [],
+      gameStartTime: null,
+      splotchDurationSec: -1,
+      round: 0,
+      loadingStatus: '',
+      relayOptions: {
+        reliable: false,
+        ordered: true
+      }
     }
-    
-    // Initialize brainCloud library
-    initBC()
-    {
-        // Create brainCloud Wrapper and initialize it
-        this.bc = new brainCloud.BrainCloudWrapper("relayservertest")
-        this.bc.initialize(ids.appId, ids.appSecret, "5.9.0")
+  }
 
-        // Set server URL if specified in ids.txt
-        if (ids.url) this.bc.brainCloudClient.setServerUrl(ids.url)
+  // Derive a display label for the brainCloud server environment
+  getServerLabel () {
+    if (!ids.url) return 'prod'
+    if (ids.url.includes('internalgb')) return 'internal-gb'
+    if (ids.url.includes('internal')) return 'internal'
+    return ids.url
+  }
 
-        // Log all the things so we can see what's going on (Turn that off for release)
-        this.bc.brainCloudClient.enableLogging(true)
+  // Reset the app to the login page with an error popup
+  dieWithMessage (message) {
+    if (autoEndTimer) {
+      clearTimeout(autoEndTimer)
+      autoEndTimer = null
     }
+    this.bc.logoutOnApplicationClose(false)
+    this.bc.relay.disconnect()
+    this.bc.relay.deregisterSystemCallback()
+    this.bc.relay.deregisterRelayCallback()
+    this.bc.rttService.deregisterAllRTTCallbacks()
+    this.bc.brainCloudClient.resetCommunication()
+    alert(message)
+    this.initBC()
+    this.setState(this.makeDefaultState())
+  }
 
-    // Create default blank state for the app
-    makeDefaultState()
-    {
-        return {
-            screen: "login",        // Current screen we are on
-            storedProfileID: null,
-            user: null,             // Our user
-            appLobbies: [],         // List of lobbies setup for the app
-            lobby: null,            // Lobby with its members as received from brainCloud Lobby Service
-            disbandOnStart: false,  // Lobby Rule. When false, the lobby will remain once a match has started, enabling users to join in-progress games
-            teams: [],              // Teams set up for a given lobby type
-            server: null,           // Server info (IP, port, protocol, passcode)
-            shockwaves: [],         // Players' created shockwaves
-            relayOptions: {
-                reliable: false,
-                ordered: true
-            }
-        }
-    }
+  // Clicked "Login"
+  onLoginClicked (user, pass) {
+    this.setState({ screen: 'loginIn' })
+    this.username = user
+    this.bc.authenticateUniversal(user, pass, true, this.onLoggedIn.bind(this))
+  }
 
-    // Reset the app to the login page with an error popup
-    dieWithMessage(message)
-    {
-        this.bc.logoutOnApplicationClose(false)
+  // brainCloud authentication response
+  onLoggedIn (result) {
+    if (result.status === 200) {
+      // Update username stored in brainCloud if first time loging in with that user.
+      if (this.username !== '' && this.username !== undefined) {
+        this.bc.playerState.updateUserName(this.username)
+      } else {
+        this.username = result.data.playerName
+      }
 
-        // Close Relay/RTT/BC connections
-        this.bc.relay.disconnect()
-        this.bc.relay.deregisterSystemCallback()
-        this.bc.relay.deregisterRelayCallback()
-        this.bc.rttService.deregisterAllRTTCallbacks()
-        this.bc.brainCloudClient.resetCommunication()
+      // Set the state with our user information. Include in there our
+      let localStorageColor = localStorage.getItem('color')
+      if (localStorageColor == null) localStorageColor = '7'
 
-        // Pop alert message
-        alert(message)
+      // Get app's lobby types and global settings
+      this.bc.globalApp.readProperties(readPropertiesResponse => {
+        if (readPropertiesResponse.status === 200) {
+          var parsedValue = JSON.parse(
+            readPropertiesResponse.data.AllLobbyTypes.value
+          )
+          var values = Object.values(parsedValue)
+          var allLobbyTypes = []
+          for (let i = 0; i < values.length; i++) {
+            allLobbyTypes[i] = values[i]
+          }
 
-        // Initialize BC libs and start over
-        this.initBC()
-
-        // Go back to default login state
-        this.setState(this.makeDefaultState())
-    }
-
-    // Clicked "Login"
-    onLoginClicked(user, pass)
-    {
-        // Show "Logging in..." screen
-        this.setState({ screen: "loginIn" })
-
-        // Connect to braincloud
-        this.username = user
-        this.bc.authenticateUniversal(user, pass, true, this.onLoggedIn.bind(this))
-    }
-
-    // brainCloud authentication response
-    onLoggedIn(result)
-    {
-        if (result.status === 200)
-        {
-            // Update username stored in brainCloud if first time loging in with that user.
-            // This is necessary because the login username is not necessary the app username (Player name)
-            if (this.username !== "" && this.username !== undefined)
-            {
-                this.bc.playerState.updateUserName(this.username)
-            }
-            else
-            {
-                this.username = result.data.playerName
-            }
-
-            // Set the state with our user information. Include in there our
-            // color pick from last time.
-            let localStorageColor = localStorage.getItem("color")
-            if (localStorageColor == null) localStorageColor = "7" // Default to white
-
-            // Get app's lobby types
-            this.bc.globalApp.readProperties((readPropertiesResponse) => {
-                if(readPropertiesResponse.status === 200){
-                    var parsedValue = JSON.parse(readPropertiesResponse.data.AllLobbyTypes.value)
-                    var values = Object.values(parsedValue)
-                    var allLobbyTypes = []
-                    
-                    for(let i = 0; i < values.length; i++){
-                        allLobbyTypes[i] = values[i]
-                    }
-
-                    this.setState({
-                        screen: "mainMenu",
-                        user: {
-                            id: result.data.profileId,
-                            cxId: null,
-                            name: this.username,
-                            colorIndex: parseInt(localStorageColor),
-                            isReady: false,
-                            presentSinceStart: false
-                        },
-                        appLobbies: allLobbyTypes
-                    })
-                }
-                else{
-                    console.log("globalApp.readProperties failed")
-                }
-            })
-        }
-        else
-        {
-            this.dieWithMessage("Failed to login");
-        }
-    }
-
-    onLogout() {
-        this.bc.logout(true, () => {
-            // Close Relay/RTT/BC connections
-            this.bc.relay.disconnect()
-            this.bc.relay.deregisterSystemCallback()
-            this.bc.relay.deregisterRelayCallback()
-            this.bc.rttService.deregisterAllRTTCallbacks()
-            this.bc.brainCloudClient.resetCommunication()
-
-            // Initialize BC libs and start over
-            this.initBC()
-
-            // Go back to default login state
-            this.setState(this.makeDefaultState())
-        })
-    }
-
-    // Clicked play from the main menu (Menu shown after authentication)
-    onPlayClicked(lobbyType) {
-        this.setState({ screen: "joiningLobby", lobbyType: lobbyType })
-
-        // Enable RTT service
-        this.bc.rttService.enableRTT(() => {
-            let state = this.state
-            let extraJson = {
-                colorIndex: this.state.user.colorIndex,
-                presentSinceStart: this.state.user.presentSinceStart
-            }
-            state.user.cxId = this.bc.rttService.getRTTConnectionId()
-            this.setState(state)
-
-            // Register lobby callback
-            this.bc.rttService.registerRTTLobbyCallback(this.onLobbyEvent.bind(this))
-
-            // If using gamelift, we will do region pings
-            if(lobbyType.toLowerCase().includes("gamelift")){
-                console.log("GameLift Lobby")
-
-                this.bc.lobby.getRegionsForLobbies([lobbyType], (result) => {
-                    if (result.status !== 200) {
-                        this.dieWithMessage("Failed to get regions for lobbies")
-                        return
-                }
-
-                this.bc.lobby.pingRegions((result) => {
-                    if (result.status !== 200) {
-                        this.dieWithMessage("Failed to ping regions")
-                        return
-                    }
-
-                    this.bc.lobby.findOrCreateLobbyWithPingData(lobbyType, 0, 1, { strategy: "ranged-absolute", alignment: "center", ranges: [1000] }, {}, null, {}, false, extraJson, "", result => {
-                        if (result.status !== 200) {
-                            this.dieWithMessage("Failed to find lobby")
-                        }
-                        // Success of lobby found will be in the event onLobbyEvent
-                    })
-                })
-            })                
-            }
-
-            else{
-                this.bc.lobby.findOrCreateLobby(lobbyType, 0, 1, { strategy: "ranged-absolute", alignment: "center", ranges: [1000] }, {}, null, {}, false, extraJson, "", result => {
-                    if (result.status !== 200) {
-                        this.dieWithMessage("Failed to find lobby")
-                    }
-                    // Success of lobby found will be in the event onLobbyEvent
-                })
-            }
-        }, () => {
-            if (this.state.screen === "joiningLobby") {
-                this.dieWithMessage("Failed to enable RTT")
-            }
-            else {
-                this.dieWithMessage("RTT Disconnected")
-            }
-        })
-    }
-
-    // Update events from the lobby Service
-    onLobbyEvent(result)
-    {
-        // If there is a lobby object present in the message, update our lobby
-        // state with it.
-        if (result.data.lobby)
-        {   
-            this.setState({lobby: { ...result.data.lobby, lobbyId: result.data.lobbyId }})
-
-            this.bc.lobby.getLobbyData(this.state.lobby.lobbyId, response => {
-                var status = response.status
-                if(status === 200){
-                    let state = this.state
-                    state.disbandOnStart = response.data.lobbyTypeDef.rules.disbandOnStart
-
-                    // Sort lobby members by team
-                    var lobbyTeams = Object.keys(response.data.lobbyTypeDef.teams)
-                    
-                    var teams = []
-                    lobbyTeams.forEach(lobbyTeam => {
-                        var team = {
-                            name: lobbyTeam,
-                            members: []
-                        }
-                        state.lobby.members.forEach(member => {
-                            if (member.team === lobbyTeam) {
-                                team.members.push(member)
-                                if (member.cxId === this.state.user.cxId) {
-                                    if (!state.user.team) {
-                                        this.onTeamChanged(member.team)
-                                    }
-                                }
-                            }
-                        })
-                        
-                        teams.push(team)
-                    })
-                    state.teams = teams
-                    console.log("updated teams " + JSON.stringify(teams))
-                    console.log("updated user: " + JSON.stringify(this.state.user))
-
-                    this.setState(state)
-                    console.log("state set")
-                }
-            })
-
-            // If we were joining lobby, show the lobby screen. We have the information to
-            // display now.
-            if (this.state.screen === "joiningLobby")
-            {
-                this.setState({ screen: "lobby" })
-            }
-        }
-
-        if (result.operation === "DISBANDED")
-        {
-            if (result.data.reason.code !== this.bc.reasonCodes.RTT_ROOM_READY)
-            {
-                // Disbanded for any other reason than ROOM_READY, means we failed to launch the game.
-                this.onGameScreenClose()
-            }
-        }
-        else if (result.operation === "STARTING")
-        {
-            presentWhileStarted = true;
-
-            this.updatePresentSinceStart();
-
-            // Game is starting, show loading screen
-            this.setState({ screen: "connecting" })
-        }
-        else if (result.operation === "ROOM_READY")
-        {
-            server = result.data;
-
-            // Server has been created. Connect to it
-
-            // Check to see if a user joined the lobby before the match started or after.
-            // If a user joins while match is in progress, you will only receive MEMBER_JOIN & ROOM_READY RTT updates.
-            if (presentWhileStarted) {
-                this.connectRelay();
-            }
-            else{
-                showJoinButton = true;
-
-                // refresh the screen to display join button
-                this.setState({ screen: "lobby" })
-            }
-        }
-    }
-
-    // Gameplay option toggles
-    onToggleReliable()
-    {
-        let state = this.state
-        state.relayOptions.reliable = !state.relayOptions.reliable
-        this.setState(state)
-    }
-
-    onToggleOrdered()
-    {
-        let state = this.state
-        state.relayOptions.ordered = !state.relayOptions.ordered
-        this.setState(state)
-    }
-
-    onTogglePlayerMask(cxId)
-    {
-        let state = this.state
-        let member = state.lobby.members.find(member => member.cxId === cxId)
-        if (member)
-        {
-            member.allowSendTo = !member.allowSendTo
-        }
-        this.setState(state)
-    }
-
-    // Called to terminate the current session and go back to the main menu
-    onGameScreenClose()
-    {
-        this.bc.relay.deregisterRelayCallback()
-        this.bc.relay.deregisterSystemCallback()
-        this.bc.relay.disconnect()
-        this.bc.rttService.deregisterAllRTTCallbacks()
-        this.bc.rttService.disableRTT()
-
-        let state = this.state
-        state.screen = "mainMenu"
-        state.lobby = null
-        state.user.isReady = false
-        state.user.presentSinceStart = false
-        state.user.team = null
-        showJoinButton = false
-        this.setState(state)
-    }
-
-    // The player has picked a different color in the Lobby menu
-    onColorChanged(colorIndex)
-    {
-        let state = this.state
-        state.user.colorIndex = colorIndex
-        let extraJson = {
-            colorIndex: colorIndex,
-            presentSinceStart: state.user.presentSinceStart
-        }
-        this.setState(state)
-
-        // Update the extra information for our player so other lobby members are notified of
-        // our color change.
-        this.bc.lobby.updateReady(this.state.lobby.lobbyId, this.state.user.isReady, extraJson)
-    }
-
-    onTeamChanged(team) {
-        let state = this.state
-        state.user.team = team
-
-        if (team === "alpha") {
-            state.user.colorIndex = 4
-            state.user.opposingTeam = "beta"
-        }
-        else if (team === "beta") {
-            state.user.colorIndex = 3
-            state.user.opposingTeam = "alpha"
-        }
-
-        this.setState(state)
-
-        this.bc.lobby.switchTeam(state.lobby.lobbyId, team, result => {
-
-            // Update the extra information for our player so other lobby members are notified of
-            // our color change.
-            if(result.status === 200){
-                this.onColorChanged(state.user.colorIndex)
-            }            
-        })
-    }
-
-    // Owner of the lobby clicked the "Start" button
-    onStart()
-    {
-        let state = this.state
-        let extraJson = {
-            colorIndex: this.state.user.colorIndex,
-            presentSinceStart: this.state.user.presentSinceStart
-        }
-        state.user.isReady = true
-        this.setState(state)
-
-        // Set our state to ready and notify the lobby Service.
-        this.bc.lobby.updateReady(this.state.lobby.lobbyId, this.state.user.isReady, extraJson)
-    }
-
-    // Player clicked the "Join Match" button, requesting to join a match that had been started prior to them joining the lobby
-    onJoin()
-    {        
-        let state = this.state
-        let extraJson = {
-            colorIndex: this.state.user.colorIndex,
-            presentSinceStart: this.state.user.presentSinceStart
-        }
-        state.user.isReady = true
-        this.setState(state)
-
-        // Set our state to ready and notify the lobby Service.
-        this.bc.lobby.updateReady(this.state.lobby.lobbyId, this.state.user.isReady, extraJson)
-        
-        this.connectRelay();
-    }
-
-    // Return to the lobby with the same players
-    onEndMatch()
-    {
-        let extraJson = {
-            cxId: this.bc.brainCloudClient.getRTTConnectionId(),
-            lobbyId: this.state.lobby.lobbyId,
-            op: "END_MATCH"
-        }
-
-        this.bc.relay.endMatch(extraJson)
-    }
-
-
-    // A relay message coming from another player
-    onRelayMessage(netId, data)
-    {
-        let state = this.state;
-        let memberCxId = this.bc.relay.getCxIdForNetId(netId)
-        let member = state.lobby.members.find(member => member.cxId === memberCxId)
-        let str = data.toString('ascii');
-        let json = JSON.parse(str)
-
-        switch (json.op)
-        {
-            // Player moved the mouse
-            case "move":   
-                member.pos = {x: json.data.x, y: json.data.y};
-                break
-
-            // Player clicked to create a shockwave
-            case "shockwave":   
-            if(json.data.teamCode === 0){
-                this.createShockwave(json.data, colors[7])
-                break
-            }    
-            this.createShockwave(json.data, colors[member.extra.colorIndex])
-                break
-
-            default: break;
-        }
-
-        this.setState(state)
-    }
-
-    // Received a Relay Server system message
-    onSystemMessage(json)
-    {
-        if (json.op === "DISCONNECT") // A member has disconnected from the game
-        {
-            let state = this.state;
-            let member = state.lobby.members.find(member => member.cxId === json.cxId)
-            if (member) member.pos = null // This will stop displaying this member
-            this.setState(state)
-        }
-        else if(json.op === "CONNECT"){            
-            let state = this.state
-            state.lobby.members.forEach(member => member.allowSendTo = (member.cxId !== state.user.cxId)
+          // Read splotch duration (-1 = forever)
+          let splotchDurationSec = -1
+          if (readPropertiesResponse.data.SplotchDuration) {
+            splotchDurationSec = parseInt(
+              readPropertiesResponse.data.SplotchDuration.value
             )
-        }
-        else if(json.op === "END_MATCH")
-        {
-            let state = this.state
-            state.screen = "lobby"
-            state.user.isReady = false;
-            state.user.presentSinceStart = false;
-            showJoinButton = false;
+          }
 
-            this.setState(state)
+          this.setState({
+            screen: 'mainMenu',
+            user: {
+              id: result.data.profileId,
+              cxId: null,
+              name: this.username,
+              colorIndex: parseInt(localStorageColor) % colors.length,
+              isReady: false,
+              presentSinceStart: false
+            },
+            appLobbies: allLobbyTypes,
+            splotchDurationSec: splotchDurationSec
+          })
+        } else {
+          console.log('globalApp.readProperties failed')
         }
+      })
+    } else {
+      this.dieWithMessage('Failed to login')
     }
+  }
 
-    // Called by the gamescreen when our player moves the mouse
-    onPlayerMove(pos)
-    {
-        let state = this.state;
-        let member = state.lobby.members.find(member => member.cxId === state.user.cxId)
-        member.pos = {x: pos.x, y: pos.y};
+  onLogout () {
+    this.bc.logout(true, () => {
+      // Close Relay/RTT/BC connections
+      this.bc.relay.disconnect()
+      this.bc.relay.deregisterSystemCallback()
+      this.bc.relay.deregisterRelayCallback()
+      this.bc.rttService.deregisterAllRTTCallbacks()
+      this.bc.brainCloudClient.resetCommunication()
+      // Initialize BC libs and start over
+      this.initBC()
+      // Go back to default login state
+      this.setState(this.makeDefaultState())
+    })
+  }
+
+  // Clicked play from the main menu
+  onPlayClicked (lobbyType) {
+    loadingTimerStart = Date.now()
+    this.setState({
+      screen: 'joiningLobby',
+      lobbyType: lobbyType,
+      loadingStatus: 'Searching...'
+    })
+
+    // Enable RTT service
+    this.bc.rttService.enableRTT(
+      () => {
+        let state = this.state
+        let extraJson = {
+          colorIndex: this.state.user.colorIndex,
+          presentSinceStart: this.state.user.presentSinceStart
+        }
+        state.user.cxId = this.bc.rttService.getRTTConnectionId()
         this.setState(state)
 
-        // We send the movement update as unreliable. Exact position is not important and we can accept
-        // packet loss.
-        // Note: This is using the JS API which uses only WebSocket, meaning there will never be packet loss. But other
-        // API can connect to the same game instance and might communicate to the relay server in UDP.
-        this.bc.relay.sendToAll(Buffer.from(JSON.stringify({op:"move",data:pos}), 'ascii'), false, true, this.bc.relay.CHANNEL_HIGH_PRIORITY_1);
-    }
+        this.bc.rttService.registerRTTLobbyCallback(
+          this.onLobbyEvent.bind(this)
+        )
 
-    // Player has clicked to create a shockwave
-    onPlayerShockwave(pos)
-    {
-        // Build player mask.
-        let playerMask = this.state.lobby.members.reduce((playerMask, member) =>
-        {
-            if (!member.allowSendTo)
-            {
-                return playerMask
+        // If using gamelift, we will do region pings
+        if (lobbyType.toLowerCase().includes('gamelift')) {
+          console.log('GameLift Lobby')
+          this.bc.lobby.getRegionsForLobbies([lobbyType], result => {
+            if (result.status !== 200) {
+              this.dieWithMessage('Failed to get regions for lobbies')
+              return
             }
-            else
-            {
-                let netId = this.bc.relay.getNetIdForCxId(member.cxId)
-
-                // Note here we don't use bitwise operations because
-                // the mask can be up to 40 players, and using bitwise limits us to 32 bits in JS.
-                // But for a game with less than 32 players, this shouldn't be a problem.
-                return playerMask + Math.pow(2, netId)
-            }
-        }, 0)
-        
-        // We send the shockewave event as reliable because such action needs to be guaranteed.
-        this.bc.relay.sendToPlayers(Buffer.from(JSON.stringify({op:"shockwave",data:pos}), 'ascii'), playerMask, true, false, this.bc.relay.CHANNEL_HIGH_PRIORITY_2);
-
-        // Create the shockwave instance on our instance
-        this.createShockwave(pos, colors[this.state.user.colorIndex])
-    }
-
-    // Player has clicked to create a shockwave
-    onPlayerClicked(pos, mouseButton) {
-
-        // TODO:  FFA mode
-        if (this.state.teams.length === 1) {
-            this.onPlayerShockwave(pos)
-        }
-
-        // TODO:  Team mode
-        else {
-            let toNetId = []
-            let reliable = true
-            let ordered = false
-            let channel = this.bc.relay.CHANNEL_HIGH_PRIORITY_2
-
-            // TODO:  TEMPORARY FIX. Get rid of .team and .opposingTeam, and switch to teamCodes everywhere to make this simpler.
-            let teamCode = this.state.user.team === "alpha" ? 1 : 2
-            let opponentCode = this.state.user.opposingTeam === "alpha" ? 2 : 1
-
-            // Left click. Send [white] shockwave to everyone
-            if (mouseButton === 0) {
-                this.bc.relay.send(this.createShockwaveJSON(pos, 0), this.bc.relay.TO_ALL_PLAYERS, reliable, ordered, channel)
-
-                this.createShockwave(pos, colors[7])
-            }
-
-            // Middle click. Send shockwave to opposite team
-            else if (mouseButton === 1) {
-                this.state.lobby.members.forEach(member => {
-                    if (member.team === this.state.user.opposingTeam) {
-                        let netId = this.bc.relay.getNetIdForCxId(member.cxId)
-                        toNetId.push(netId)
-                    }
-                })
-
-                toNetId.forEach(netId => {
-                    this.bc.relay.send(this.createShockwaveJSON(pos, opponentCode), netId, reliable, ordered, channel)
-                })
-
-                this.createShockwave(pos, colors[this.state.user.colorIndex])
-            }
-
-            // Right click. Send shockwave to teammates
-            else if (mouseButton === 2) {
-                this.state.lobby.members.forEach(member => {
-                    if (member.team === this.state.user.team) {
-                        let netId = this.bc.relay.getNetIdForCxId(member.cxId)
-                        toNetId.push(netId)
-                    }
-                })
-
-                toNetId.forEach(netId => {
-                    this.bc.relay.send(this.createShockwaveJSON(pos, teamCode), netId, reliable, ordered, channel)
-                })
-
-                this.createShockwave(pos, colors[this.state.user.colorIndex])
-            }
-        }
-
-    }
-
-    connectRelay() {
-        
-        // If the lobby is gamelift, the port name will be "gamelift"
-        let wsPort = 0;
-        if (this.state.lobbyType.toLowerCase().includes("gamelift")) {
-            wsPort = server.connectData.ports.gamelift;
-        }
-
-        else if (this.state.lobbyType.toLowerCase().includes("i3d")) {
-            wsPort = server.connectData.ports.i3d;
-            console.log("i3d detected");
-        }
-        else {
-            wsPort = server.connectData.ports.ws;
-        }
-        
-        presentWhileStarted = false;
-
-        this.bc.relay.registerRelayCallback(this.onRelayMessage.bind(this))
-        this.bc.relay.registerSystemCallback(this.onSystemMessage.bind(this))
-        this.bc.relay.connect({
-            ssl: false,
-            host: server.connectData.address,
-            port: wsPort,
-            passcode: server.passcode,
-            lobbyId: server.lobbyId
-        }, result => {
-            let state = this.state
-            state.screen = "game"
-            this.setState(state)
-        }, error => this.dieWithMessage("Failed to connect to server, msg: " + error))
-    }
-
-    updatePresentSinceStart()
-    {
-        let state = this.state
-        state.user.presentSinceStart = true;
-        state.user.isReady = true;
-        
-        let extraJson = {
-            colorIndex: this.state.user.colorIndex,
-            presentSinceStart: this.state.user.presentSinceStart
-        }
-        this.bc.lobby.updateReady(this.state.lobby.lobbyId, this.state.user.isReady, extraJson)
-
-    }
-
-    // Create shockwave JSON for to send to lobby members
-    createShockwaveJSON(pos, intendedTeam){
-        let shockwaveData = {
-            x: pos.x,
-            y: pos.y,
-            teamCode: intendedTeam,
-            instigator: this.state.user.team === "alpha" ? 1 : 2
-        }
-        
-        return Buffer.from(JSON.stringify({ op: "shockwave", data: shockwaveData }), 'ascii')
-    }
-
-    // Create a shockwave at position and color on the game screen
-    createShockwave(pos, color)
-    {
-        let shockwaves = this.state.shockwaves;
-        let shockwave = {
-            pos: {x: pos.x * 800, y: pos.y * 600},
-            color: color,
-            id: this.shockwaveNextId++ // This is used to ID the HTML element so the CSS animation doesn't bug.
-        }
-        shockwaves.push(shockwave)
-        this.setState({shockwaves: shockwaves})
-
-        // Set a timeout to kill that shockwave instance in 1 second
-        setTimeout(() =>
-        {
-            let shockwaves = this.state.shockwaves;
-            shockwaves.splice(shockwaves.indexOf(shockwave), 1)
-            this.setState({shockwaves: shockwaves})
-        }, 1000)
-    }
-
-    // Render ReactJS components
-    render()
-    {
-        switch (this.state.screen)
-        {
-            case "reconnecting":
+            this.bc.lobby.pingRegions(result => {
+              if (result.status !== 200) {
+                this.dieWithMessage('Failed to ping regions')
+                return
+              }
+              this.bc.lobby.findOrCreateLobbyWithPingData(
+                lobbyType,
+                0,
+                1,
                 {
-                    return (
-                        <div className="App">
-                            <header className="App-header">
-                                <LoadingScreen text="Reconnecting . . ."/>
-                            </header>
-                        </div>
-                    )
+                  strategy: 'ranged-absolute',
+                  alignment: 'center',
+                  ranges: [1000]
+                },
+                {},
+                null,
+                {},
+                false,
+                extraJson,
+                '',
+                result => {
+                  if (result.status !== 200) {
+                    this.dieWithMessage('Failed to find lobby')
+                  }
                 }
-            case "login":
+              )
+            })
+          })
+        } else {
+          this.bc.lobby.findOrCreateLobby(
+            lobbyType,
+            0,
+            1,
             {
-                return (
-                    <div className="App">
-                        <header className="App-header">
-                            <h1>Relay Server Test App</h1>
-                            <LoginScreen onLogin={this.onLoginClicked.bind(this)}/>
-                        </header>
-                    </div>
-                )
+              strategy: 'ranged-absolute',
+              alignment: 'center',
+              ranges: [1000]
+            },
+            {},
+            null,
+            {},
+            false,
+            extraJson,
+            '',
+            result => {
+              if (result.status !== 200) {
+                this.dieWithMessage('Failed to find lobby')
+              }
             }
-            case "loginIn":
-            {
-                return (
-                    <div className="App">
-                        <header className="App-header">
-                            <LoadingScreen text="Logging in..." />
-                        </header>
-                    </div>
-                )
-            }
-            case "mainMenu":
-            {
-                return (
-                    <div className="App">
-                        <header className="App-header">
-                            <h1>Relay Server Test App</h1>
-                            <MainMenuScreen 
-                                user={this.state.user}
-                                appLobbies={this.state.appLobbies}
-                                onLogout={this.onLogout.bind(this)}
-                                onPlay={this.onPlayClicked.bind(this)} />
-                        </header>
-                    </div>
-                )
-            }
-            case "joiningLobby":
-            {
-                return (
-                    <div className="App">
-                        <header className="App-header">
-                            <LoadingScreen text="Joining..." onBack={this.onGameScreenClose.bind(this)} />
-                        </header>
-                    </div>
-                )
-            }
-            case "lobby":
-            {   
-                return (
-                    <div className="App">
-                        <header className="App-header">
-                            <h1>Relay Server Test App</h1>
-                            <LobbyScreen 
-                                user={this.state.user}
-                                lobby={this.state.lobby}
-                                teams={this.state.teams}
-                                onBack={this.onGameScreenClose.bind(this)}
-                                onColorChanged={this.onColorChanged.bind(this)}
-                                onTeamChanged={this.onTeamChanged.bind(this)}
-                                onStart={this.onStart.bind(this)}
-                                onJoin={this.onJoin.bind(this)}/>
-                        </header>
-                    </div>
-                )
-            }
-            case "connecting":
-            {
-                return (
-                    <div className="App">
-                        <header className="App-header">
-                            <LoadingScreen text="Joining Match..." />
-                            {/*<small>If this takes a while, don't worry. This means a new server is warming up just for you.</small>*/}
-                        </header>
-                    </div>
-                )
-            }
-            case "game":
-            {
-                return (
-                    <div className="App">
-                        <header className="App-header">
-                            <h1>Relay Server Test App</h1>
-                            <small>Move mouse around and click to create shockwaves.</small>
-                            <GameScreen
-                                user={this.state.user}
-                                lobby={this.state.lobby}
-                                lobbyType={this.state.lobbyType}
-                                disbandOnStart={this.state.disbandOnStart}
-                                teams={this.state.teams}
-                                shockwaves={this.state.shockwaves}
-                                relayOptions={this.state.relayOptions}
-                                onBack={this.onGameScreenClose.bind(this)}
-                                onEndMatch={this.onEndMatch.bind(this)}
-                                onPlayerMove={this.onPlayerMove.bind(this)}
-                                onPlayerClicked={this.onPlayerClicked.bind(this)}
-                                onToggleReliable={this.onToggleReliable.bind(this)}
-                                onToggleOrdered={this.onToggleOrdered.bind(this)}
-                                onTogglePlayerMask={this.onTogglePlayerMask.bind(this)} />
-                        </header>
-                    </div>
-                )
-            }
-            default:
-            {
-                return (
-                    <div className="App">
-                        Invalid state
-                    </div>
-                )
-            }
+          )
         }
+      },
+      () => {
+        if (this.state.screen === 'joiningLobby') {
+          this.dieWithMessage('Failed to enable RTT')
+        } else {
+          this.dieWithMessage('RTT Disconnected')
+        }
+      }
+    )
+  }
+
+  // Update events from the lobby service
+  onLobbyEvent (result) {
+    if (result.data.lobby) {
+      this.setState({
+        lobby: { ...result.data.lobby, lobbyId: result.data.lobbyId }
+      })
+
+      this.bc.lobby.getLobbyData(this.state.lobby.lobbyId, response => {
+        var status = response.status
+        if (status === 200) {
+          let state = this.state
+          state.disbandOnStart = response.data.lobbyTypeDef.rules.disbandOnStart
+
+          var lobbyTeams = Object.keys(response.data.lobbyTypeDef.teams)
+          var teams = []
+          lobbyTeams.forEach(lobbyTeam => {
+            var team = { name: lobbyTeam, members: [] }
+            state.lobby.members.forEach(member => {
+              if (member.team === lobbyTeam) {
+                team.members.push(member)
+                if (member.cxId === this.state.user.cxId) {
+                  if (!state.user.team) {
+                    this.onTeamChanged(member.team)
+                  }
+                }
+              }
+            })
+            teams.push(team)
+          })
+          state.teams = teams
+          this.setState(state)
+        }
+      })
+
+      if (this.state.screen === 'joiningLobby') {
+        this.setState({ screen: 'lobby' })
+      }
     }
+
+    if (result.operation === 'DISBANDED') {
+      if (result.data.reason.code !== this.bc.reasonCodes.RTT_ROOM_READY) {
+        this.onGameScreenClose()
+      }
+    } else if (result.operation === 'MATCHMAKING_IN_PROGRESS') {
+      this.setState({ loadingStatus: 'Searching for lobby...' })
+    } else if (result.operation === 'MEMBER_JOIN') {
+      let joinedName =
+        result.data && result.data.member ? result.data.member.name : 'Player'
+      this.setState({ loadingStatus: `Joined: ${joinedName}` })
+    } else if (result.operation === 'MEMBER_LEFT') {
+      this.setState({ loadingStatus: 'A player left the lobby.' })
+    } else if (result.operation === 'STARTING') {
+      presentWhileStarted = true
+      this.updatePresentSinceStart()
+      this.setState({
+        screen: 'connecting',
+        loadingStatus: 'Provisioning server...'
+      })
+    } else if (result.operation === 'ROOM_ASSIGNED') {
+      this.setState({ loadingStatus: 'Server assigned...' })
+    } else if (result.operation === 'ROOM_PROGRESS') {
+      let step = result.data && result.data.step ? result.data.step : ''
+      let msg = result.data && result.data.msg ? result.data.msg : ''
+      this.setState({
+        loadingStatus: step ? `${step}: ${msg}` : msg || 'Starting server...'
+      })
+    } else if (result.operation === 'ROOM_READY') {
+      server = result.data
+      this.setState({ loadingStatus: 'Connecting...' })
+      if (presentWhileStarted) {
+        this.connectRelay()
+      } else {
+        showJoinButton = true
+        this.setState({ screen: 'lobby' })
+      }
+    }
+  }
+
+  // Gameplay option toggles
+  onToggleReliable () {
+    let state = this.state
+    state.relayOptions.reliable = !state.relayOptions.reliable
+    this.setState(state)
+  }
+
+  onToggleOrdered () {
+    let state = this.state
+    state.relayOptions.ordered = !state.relayOptions.ordered
+    this.setState(state)
+  }
+
+  onTogglePlayerMask (cxId) {
+    let state = this.state
+    let member = state.lobby.members.find(member => member.cxId === cxId)
+    if (member) member.allowSendTo = !member.allowSendTo
+    this.setState(state)
+  }
+
+  // Called to terminate the current session and go back to the main menu
+  onGameScreenClose () {
+    if (autoEndTimer) {
+      clearTimeout(autoEndTimer)
+      autoEndTimer = null
+    }
+    this.bc.relay.deregisterRelayCallback()
+    this.bc.relay.deregisterSystemCallback()
+    this.bc.relay.disconnect()
+    this.bc.rttService.deregisterAllRTTCallbacks()
+    this.bc.rttService.disableRTT()
+
+    let state = this.state
+    state.screen = 'mainMenu'
+    state.lobby = null
+    state.user.isReady = false
+    state.user.presentSinceStart = false
+    state.user.team = null
+    state.splotches = []
+    state.shockwaves = []
+    state.gameStartTime = null
+    state.round = 0
+    state.loadingStatus = ''
+    showJoinButton = false
+    loadingTimerStart = null
+    this.setState(state)
+  }
+
+  // The player has picked a different color in the Lobby menu
+  onColorChanged (colorIndex) {
+    let state = this.state
+    state.user.colorIndex = colorIndex
+    let extraJson = {
+      colorIndex: colorIndex,
+      presentSinceStart: state.user.presentSinceStart
+    }
+    this.setState(state)
+    this.bc.lobby.updateReady(
+      this.state.lobby.lobbyId,
+      this.state.user.isReady,
+      extraJson
+    )
+  }
+
+  onTeamChanged (team) {
+    let state = this.state
+    state.user.team = team
+
+    if (team === 'alpha') {
+      state.user.colorIndex = 6 // vivid sky blue
+      state.user.opposingTeam = 'beta'
+    } else if (team === 'beta') {
+      state.user.colorIndex = 0 // vivid red
+      state.user.opposingTeam = 'alpha'
+    }
+
+    this.setState(state)
+
+    this.bc.lobby.switchTeam(state.lobby.lobbyId, team, result => {
+      if (result.status === 200) {
+        this.onColorChanged(state.user.colorIndex)
+      }
+    })
+  }
+
+  // Owner of the lobby clicked the "Start" button
+  onStart () {
+    let state = this.state
+    let extraJson = {
+      colorIndex: this.state.user.colorIndex,
+      presentSinceStart: this.state.user.presentSinceStart
+    }
+    state.user.isReady = true
+    this.setState(state)
+    this.bc.lobby.updateReady(
+      this.state.lobby.lobbyId,
+      this.state.user.isReady,
+      extraJson
+    )
+  }
+
+  // Player clicked the "Join Match" button to join an in-progress game
+  onJoin () {
+    let state = this.state
+    let extraJson = {
+      colorIndex: this.state.user.colorIndex,
+      presentSinceStart: this.state.user.presentSinceStart
+    }
+    state.user.isReady = true
+    this.setState(state)
+    this.bc.lobby.updateReady(
+      this.state.lobby.lobbyId,
+      this.state.user.isReady,
+      extraJson
+    )
+    this.connectRelay()
+  }
+
+  // Return to the lobby with the same players (host-only)
+  onEndMatch () {
+    if (autoEndTimer) {
+      clearTimeout(autoEndTimer)
+      autoEndTimer = null
+    }
+    let extraJson = {
+      cxId: this.bc.brainCloudClient.getRTTConnectionId(),
+      lobbyId: this.state.lobby.lobbyId,
+      op: 'END_MATCH'
+    }
+    this.bc.relay.endMatch(extraJson)
+  }
+
+  // Host clears all splotches from the canvas
+  onClearSplotches () {
+    this.setState({ splotches: [] })
+    this.bc.relay.sendToAll(
+      Buffer.from(JSON.stringify({ op: 'clear_splotches' }), 'ascii'),
+      true,
+      false,
+      this.bc.relay.CHANNEL_HIGH_PRIORITY_2
+    )
+  }
+
+  // A relay message coming from another player
+  onRelayMessage (netId, data) {
+    let state = this.state
+    let memberCxId = this.bc.relay.getCxIdForNetId(netId)
+    let member = state.lobby.members.find(member => member.cxId === memberCxId)
+    let str = data.toString('ascii')
+    let json = JSON.parse(str)
+
+    switch (json.op) {
+      // Player moved the mouse
+      case 'move':
+        if (member) member.pos = { x: json.data.x, y: json.data.y }
+        break
+
+      // Player clicked — leave a persistent splotch
+      case 'shockwave':
+        let colorIndex =
+          member && member.extra ? member.extra.colorIndex % colors.length : 0
+        state.splotches.push({
+          x: json.data.x,
+          y: json.data.y,
+          colorIndex: colorIndex,
+          startTimeMs: Date.now()
+        })
+
+        this.createShockwave(json.data, colors[member.extra.colorIndex])
+        break
+
+      // Host is syncing game start time (also sent to JIP players)
+      case 'game_start':
+        state.gameStartTime = json.data.startTime
+        state.round = json.data.round
+        break
+
+      // Host is syncing splotch canvas to a newly joined player
+      case 'splotch_sync':
+        if (json.data.first) state.splotches = []
+        json.data.splotches.forEach(s => {
+          state.splotches.push({
+            x: s.x,
+            y: s.y,
+            colorIndex: s.c,
+            startTimeMs: s.t
+          })
+        })
+        break
+
+      // Host cleared all splotches
+      case 'clear_splotches':
+        state.splotches = []
+        break
+
+      default:
+        break
+    }
+
+    this.setState(state)
+  }
+
+  // Received a Relay Server system message
+  onSystemMessage (json) {
+    if (json.op === 'DISCONNECT') {
+      let state = this.state
+      let member = state.lobby.members.find(member => member.cxId === json.cxId)
+      if (member) member.pos = null
+      this.setState(state)
+    } else if (json.op === 'CONNECT') {
+      let state = this.state
+      state.lobby.members.forEach(
+        member => (member.allowSendTo = member.cxId !== state.user.cxId)
+      )
+      this.setState(state)
+
+      // If we are the host and in-game, send current state to the newly joined player
+      if (
+        state.lobby.ownerCxId === state.user.cxId &&
+        state.screen === 'game'
+      ) {
+        let newPlayerNetId = this.bc.relay.getNetIdForCxId(json.cxId)
+        let mask = Math.pow(2, newPlayerNetId)
+        this.sendGameStartToMask(mask)
+        this.sendSplotchSyncToMask(mask)
+      }
+    } else if (json.op === 'END_MATCH') {
+      if (autoEndTimer) {
+        clearTimeout(autoEndTimer)
+        autoEndTimer = null
+      }
+      let state = this.state
+      state.screen = 'lobby'
+      state.user.isReady = false
+      state.user.presentSinceStart = false
+      state.splotches = []
+      state.shockwaves = []
+      state.gameStartTime = null
+      showJoinButton = false
+      this.setState(state)
+    }
+  }
+
+  // Called by the game screen when our player moves the mouse
+  onPlayerMove (pos) {
+    let state = this.state
+    let member = state.lobby.members.find(
+      member => member.cxId === state.user.cxId
+    )
+    member.pos = { x: pos.x, y: pos.y }
+    this.setState(state)
+
+    this.bc.relay.sendToAll(
+      Buffer.from(JSON.stringify({ op: 'move', data: pos }), 'ascii'),
+      false,
+      true,
+      this.bc.relay.CHANNEL_HIGH_PRIORITY_1
+    )
+  }
+
+  // FFA: player clicked to create a splotch visible to all (filtered by player mask)
+  onPlayerSplotch (pos) {
+    let playerMask = this.state.lobby.members.reduce((playerMask, member) => {
+      if (!member.allowSendTo) return playerMask
+      let netId = this.bc.relay.getNetIdForCxId(member.cxId)
+      // Note: we avoid bitwise ops here to support up to 40 players (JS bitwise is 32-bit)
+      return playerMask + Math.pow(2, netId)
+    }, 0)
+
+    this.bc.relay.sendToPlayers(
+      Buffer.from(
+        JSON.stringify({
+          op: 'shockwave',
+          data: { x: pos.x, y: pos.y, teamCode: 0 }
+        }),
+        'ascii'
+      ),
+      playerMask,
+      true,
+      false,
+      this.bc.relay.CHANNEL_HIGH_PRIORITY_2
+    )
+
+    this.createSplotch(pos, this.state.user.colorIndex)
+    this.createShockwave(pos, colors[this.state.user.colorIndex])
+  }
+
+  // Dispatch a click based on mouse button and team mode
+  onPlayerClicked (pos, mouseButton) {
+    // FFA mode
+    if (this.state.teams.length === 1) {
+      this.onPlayerSplotch(pos)
+      return
+    }
+
+    // Team mode
+    let toNetId = []
+    let reliable = true
+    let ordered = false
+    let channel = this.bc.relay.CHANNEL_HIGH_PRIORITY_2
+    let teamCode = this.state.user.team === 'alpha' ? 1 : 2
+    let opponentCode = this.state.user.opposingTeam === 'alpha' ? 1 : 2
+
+    // Left click — splotch to everyone
+    if (mouseButton === 0) {
+      this.bc.relay.send(
+        Buffer.from(
+          JSON.stringify({
+            op: 'shockwave',
+            data: { x: pos.x, y: pos.y, teamCode: 0 }
+          }),
+          'ascii'
+        ),
+        this.bc.relay.TO_ALL_PLAYERS,
+        reliable,
+        ordered,
+        channel
+      )
+      this.createSplotch(pos, this.state.user.colorIndex)
+      this.createShockwave(pos, colors[this.state.user.colorIndex])
+    }
+    // Middle click — splotch to opponents
+    else if (mouseButton === 1) {
+      this.state.lobby.members.forEach(member => {
+        if (member.team === this.state.user.opposingTeam) {
+          toNetId.push(this.bc.relay.getNetIdForCxId(member.cxId))
+        }
+      })
+      toNetId.forEach(netId => {
+        this.bc.relay.send(
+          Buffer.from(
+            JSON.stringify({
+              op: 'shockwave',
+              data: { x: pos.x, y: pos.y, teamCode: opponentCode }
+            }),
+            'ascii'
+          ),
+          netId,
+          reliable,
+          ordered,
+          channel
+        )
+      })
+      this.createSplotch(pos, this.state.user.colorIndex)
+      this.createShockwave(pos, colors[this.state.user.colorIndex])
+    }
+    // Right click — splotch to teammates
+    else if (mouseButton === 2) {
+      this.state.lobby.members.forEach(member => {
+        if (member.team === this.state.user.team) {
+          toNetId.push(this.bc.relay.getNetIdForCxId(member.cxId))
+        }
+      })
+      toNetId.forEach(netId => {
+        this.bc.relay.send(
+          Buffer.from(
+            JSON.stringify({
+              op: 'shockwave',
+              data: { x: pos.x, y: pos.y, teamCode: teamCode }
+            }),
+            'ascii'
+          ),
+          netId,
+          reliable,
+          ordered,
+          channel
+        )
+      })
+      this.createSplotch(pos, this.state.user.colorIndex)
+      this.createShockwave(pos, colors[this.state.user.colorIndex])
+    }
+  }
+
+  connectRelay () {
+    let wsPort = 0
+    if (this.state.lobbyType.toLowerCase().includes('gamelift')) {
+      wsPort = server.connectData.ports.gamelift
+    } else if (this.state.lobbyType.toLowerCase().includes('i3d')) {
+      wsPort = server.connectData.ports.i3d
+      console.log('i3d detected')
+    } else {
+      wsPort = server.connectData.ports.ws
+    }
+
+    presentWhileStarted = false
+
+    this.bc.relay.registerRelayCallback(this.onRelayMessage.bind(this))
+    this.bc.relay.registerSystemCallback(this.onSystemMessage.bind(this))
+    this.bc.relay.connect(
+      {
+        ssl: false,
+        host: server.connectData.address,
+        port: wsPort,
+        passcode: server.passcode,
+        lobbyId: server.lobbyId
+      },
+      result => {
+        let state = this.state
+        state.screen = 'game'
+
+        // Host sets the authoritative game start time and broadcasts it to all players
+        if (state.lobby.ownerCxId === state.user.cxId) {
+          state.gameStartTime = Date.now()
+          state.round = (state.round || 0) + 1
+          this.setState(state)
+          this.sendGameStartToMask(this.bc.relay.TO_ALL_PLAYERS)
+          this.scheduleAutoEnd()
+        } else {
+          this.setState(state)
+        }
+      },
+      error => this.dieWithMessage('Failed to connect to server, msg: ' + error)
+    )
+  }
+
+  // Send game start time and round to a player mask (used for initial broadcast and JIP sync)
+  sendGameStartToMask (mask) {
+    let msg = {
+      op: 'game_start',
+      data: {
+        startTime: this.state.gameStartTime,
+        round: this.state.round
+      }
+    }
+    this.bc.relay.sendToPlayers(
+      Buffer.from(JSON.stringify(msg), 'ascii'),
+      mask,
+      true,
+      false,
+      this.bc.relay.CHANNEL_HIGH_PRIORITY_2
+    )
+  }
+
+  // Send the full splotch canvas to a player mask in chunked packets
+  sendSplotchSyncToMask (mask) {
+    const MAX_BYTES = 900
+    let splotches = this.state.splotches
+    let isFirst = true
+    let batch = []
+    let currentSize = 80 // rough envelope overhead
+
+    const sendBatch = (first, splotchBatch) => {
+      let msg = {
+        op: 'splotch_sync',
+        data: { first: first, splotches: splotchBatch }
+      }
+      this.bc.relay.sendToPlayers(
+        Buffer.from(JSON.stringify(msg), 'ascii'),
+        mask,
+        true,
+        false,
+        this.bc.relay.CHANNEL_HIGH_PRIORITY_2
+      )
+    }
+
+    for (let i = 0; i < splotches.length; i++) {
+      let s = splotches[i]
+      let entry = { x: s.x, y: s.y, c: s.colorIndex, t: s.startTimeMs }
+      let entrySize = JSON.stringify(entry).length + 1 // +1 for comma separator
+
+      if (currentSize + entrySize > MAX_BYTES && batch.length > 0) {
+        sendBatch(isFirst, batch)
+        isFirst = false
+        batch = []
+        currentSize = 80
+      }
+
+      batch.push(entry)
+      currentSize += entrySize
+    }
+
+    // Send remaining batch (also handles empty canvas, signalling JIP player to clear)
+    sendBatch(isFirst, batch)
+  }
+
+  // Schedule auto-end of match at MATCH_DURATION_SEC seconds (host only)
+  scheduleAutoEnd () {
+    if (autoEndTimer) clearTimeout(autoEndTimer)
+    autoEndTimer = setTimeout(() => {
+      autoEndTimer = null
+      this.onEndMatch()
+    }, MATCH_DURATION_SEC * 1000)
+  }
+
+  // Add a persistent colour splotch at pos (normalized 0-1 coords)
+  createSplotch (pos, colorIndex) {
+    let splotch = {
+      x: pos.x,
+      y: pos.y,
+      colorIndex: colorIndex % colors.length,
+      startTimeMs: Date.now()
+    }
+    let state = this.state
+    state.splotches.push(splotch)
+    this.setState(state)
+  }
+
+  // Add a transient shockwave ring at pos (normalized 0-1 coords), auto-removed after 1s
+  createShockwave (pos, color) {
+    let shockwave = {
+      pos: { x: pos.x * 800, y: pos.y * 600 },
+      color: color,
+      id: this.shockwaveNextId++
+    }
+    let state = this.state
+    state.shockwaves.push(shockwave)
+    this.setState(state)
+
+    setTimeout(() => {
+      let sw = this.state.shockwaves
+      sw.splice(sw.indexOf(shockwave), 1)
+      this.setState({ shockwaves: sw })
+    }, 1000)
+  }
+
+  updatePresentSinceStart () {
+    let state = this.state
+    state.user.presentSinceStart = true
+    state.user.isReady = true
+
+    let extraJson = {
+      colorIndex: this.state.user.colorIndex,
+      presentSinceStart: this.state.user.presentSinceStart
+    }
+    this.bc.lobby.updateReady(
+      this.state.lobby.lobbyId,
+      this.state.user.isReady,
+      extraJson
+    )
+  }
+
+  // Version overlay — always visible in the bottom-left corner on every screen
+  renderVersionOverlay () {
+    return (
+      <div className='VersionOverlay'>
+        <div>App: v{APP_VERSION}</div>
+        <div>App ID: {ids.appId}</div>
+        <div>Server: {this.getServerLabel()}</div>
+      </div>
+    )
+  }
+
+  // Inner screen content (no outer wrapper — render() provides that)
+  renderScreen () {
+    switch (this.state.screen) {
+      case 'reconnecting':
+        return <LoadingScreen text='Reconnecting . . .' />
+
+      case 'login':
+        return (
+          <>
+            <h1>Cursor Party</h1>
+            <LoginScreen onLogin={this.onLoginClicked.bind(this)} />
+          </>
+        )
+
+      case 'loginIn':
+        return <LoadingScreen text='Logging in...' />
+
+      case 'mainMenu':
+        return (
+          <>
+            <h1>Cursor Party</h1>
+            <MainMenuScreen
+              user={this.state.user}
+              appLobbies={this.state.appLobbies}
+              onLogout={this.onLogout.bind(this)}
+              onPlay={this.onPlayClicked.bind(this)}
+            />
+          </>
+        )
+
+      case 'joiningLobby':
+        return (
+          <LoadingScreen
+            text='Finding lobby...'
+            statusText={this.state.loadingStatus}
+            lobbyId={this.state.lobby ? this.state.lobby.lobbyId : null}
+            startTime={loadingTimerStart}
+            onBack={this.onGameScreenClose.bind(this)}
+          />
+        )
+
+      case 'lobby':
+        return (
+          <>
+            <h1>Cursor Party</h1>
+            <LobbyScreen
+              user={this.state.user}
+              lobby={this.state.lobby}
+              teams={this.state.teams}
+              onBack={this.onGameScreenClose.bind(this)}
+              onColorChanged={this.onColorChanged.bind(this)}
+              onTeamChanged={this.onTeamChanged.bind(this)}
+              onStart={this.onStart.bind(this)}
+              onJoin={this.onJoin.bind(this)}
+            />
+          </>
+        )
+
+      case 'connecting':
+        return (
+          <LoadingScreen
+            text='Joining match...'
+            statusText={this.state.loadingStatus}
+            lobbyId={this.state.lobby ? this.state.lobby.lobbyId : null}
+            startTime={loadingTimerStart}
+          />
+        )
+
+      case 'game':
+        return (
+          <>
+            <h1>Cursor Party</h1>
+            <small>
+              Move mouse around and click to leave colour splotches.
+            </small>
+            <GameScreen
+              user={this.state.user}
+              lobby={this.state.lobby}
+              lobbyType={this.state.lobbyType}
+              disbandOnStart={this.state.disbandOnStart}
+              teams={this.state.teams}
+              shockwaves={this.state.shockwaves}
+              splotches={this.state.splotches}
+              splotchDurationSec={this.state.splotchDurationSec}
+              gameStartTime={this.state.gameStartTime}
+              relayOptions={this.state.relayOptions}
+              onBack={this.onGameScreenClose.bind(this)}
+              onEndMatch={this.onEndMatch.bind(this)}
+              onClearSplotches={this.onClearSplotches.bind(this)}
+              onPlayerMove={this.onPlayerMove.bind(this)}
+              onPlayerClicked={this.onPlayerClicked.bind(this)}
+              onToggleReliable={this.onToggleReliable.bind(this)}
+              onToggleOrdered={this.onToggleOrdered.bind(this)}
+              onTogglePlayerMask={this.onTogglePlayerMask.bind(this)}
+              numArrowImages={NUM_ARROW_IMAGES}
+            />
+          </>
+        )
+
+      default:
+        return <p>Invalid state</p>
+    }
+  }
+
+  // Render ReactJS components
+  render () {
+    return (
+      <div className='App'>
+        {this.renderVersionOverlay()}
+        <header className='App-header'>{this.renderScreen()}</header>
+      </div>
+    )
+  }
 }
 
-export default App;
+export default App

--- a/RelayTestApp/src/Colors.js
+++ b/RelayTestApp/src/Colors.js
@@ -1,11 +1,46 @@
 exports.colors = [
-    "#000000",
-    "#55415f",
-    "#646964",
-    "#d77355",
-    "#508cd7",
-    "#64b964",
-    "#e6c86e",
-    "#dcf5ff"
+  // Row 1: vivid saturated (0-9)
+  '#FF3333', // 0  vivid red
+  '#FF8800', // 1  vivid orange
+  '#FFD700', // 2  gold
+  '#88FF00', // 3  vivid lime
+  '#00EE44', // 4  vivid green
+  '#00DDDD', // 5  vivid cyan
+  '#00AAFF', // 6  vivid sky blue
+  '#3355FF', // 7  vivid blue
+  '#AA00FF', // 8  vivid purple
+  '#FF00BB', // 9  vivid magenta
+  // Row 2: vivid-medium / complementary (10-19)
+  '#FF5566', // 10 coral
+  '#FFAA00', // 11 amber
+  '#AADD00', // 12 yellow-green
+  '#00FF88', // 13 spring green
+  '#00FFCC', // 14 aqua
+  '#0088FF', // 15 azure
+  '#8833FF', // 16 violet
+  '#FF44AA', // 17 hot pink
+  '#77FF33', // 18 chartreuse
+  '#FF6688', // 19 rose
+  // Row 3: pastel / light (20-29)
+  '#FF9999', // 20 light red
+  '#FFCC88', // 21 peach
+  '#FFFF88', // 22 pale yellow
+  '#AAFFAA', // 23 pale green
+  '#88FFEE', // 24 pale cyan
+  '#AABBFF', // 25 periwinkle
+  '#DDBBFF', // 26 lavender
+  '#FFBBDD', // 27 light pink
+  '#CCFFDD', // 28 mint
+  '#FFEECC', // 29 cream
+  // Row 4: medium-depth / muted (30-39)
+  '#CC1133', // 30 crimson
+  '#CC5500', // 31 burnt orange
+  '#88AA00', // 32 olive
+  '#228855', // 33 forest green
+  '#009999', // 34 deep teal
+  '#3366AA', // 35 steel blue
+  '#7744CC', // 36 medium purple
+  '#AA3366', // 37 dark rose
+  '#AA6633', // 38 brown
+  '#7788AA' // 39 slate
 ]
-// A7226E   EC2049   F26B38   F7DB4F   2F9599

--- a/RelayTestApp/src/GameScreen.js
+++ b/RelayTestApp/src/GameScreen.js
@@ -2,145 +2,286 @@ import React, { Component } from 'react'
 
 let colors = require('./Colors').colors
 
+const MATCH_DURATION_SEC = 90
+const COUNTDOWN_FROM_SEC = 80
+
 // Props:
 // user
 // lobby
-// lobby type
-// pings
-// relayOptions
-//   reliable
-//   ordered
-class GameScreen extends Component
-{
-    constructor()
-    {
-        super()
-        this.mousePos = {x: 0, y: 0}
+// lobbyType
+// disbandOnStart
+// teams
+// splotches
+// splotchDurationSec
+// gameStartTime
+// relayOptions { reliable, ordered }
+// numArrowImages
+// onBack / onEndMatch / onClearSplotches
+// onPlayerMove / onPlayerClicked
+// onToggleReliable / onToggleOrdered / onTogglePlayerMask
+class GameScreen extends Component {
+  constructor () {
+    super()
+    this.mousePos = { x: 0, y: 0 }
+  }
+
+  componentDidMount () {
+    // Re-render every second to update the game timer and splotch fade-out
+    this.timerInterval = setInterval(() => this.forceUpdate(), 1000)
+  }
+
+  componentWillUnmount () {
+    clearInterval(this.timerInterval)
+  }
+
+  onBack () {
+    this.props.onBack()
+  }
+  onEndMatch () {
+    this.props.onEndMatch()
+  }
+  onClearSplotches () {
+    this.props.onClearSplotches()
+  }
+
+  onMouseMove (e) {
+    let elem = document.querySelector('.GamePlayArea')
+    let rect = elem.getBoundingClientRect()
+    this.mousePos.x = (e.clientX - rect.left) / 800
+    this.mousePos.y = (e.clientY - rect.top) / 600
+    this.props.onPlayerMove(this.mousePos)
+  }
+
+  onMouseClick (e) {
+    this.props.onPlayerClicked(this.mousePos, e.button)
+  }
+  onToggleReliable () {
+    this.props.onToggleReliable()
+  }
+  onToggleOrdered () {
+    this.props.onToggleOrdered()
+  }
+  onTogglePlayerMask (cxId) {
+    this.props.onTogglePlayerMask(cxId)
+  }
+
+  showEndMatchButton () {
+    return (
+      this.props.lobby.ownerCxId === this.props.user.cxId &&
+      !this.props.disbandOnStart
+    )
+  }
+
+  showClearSplotchesButton () {
+    return this.props.lobby.ownerCxId === this.props.user.cxId
+  }
+
+  // Render the game timer. Shows countdown in the final 10 seconds.
+  renderTimer () {
+    if (!this.props.gameStartTime) return null
+    let elapsedMs = Date.now() - this.props.gameStartTime
+    let elapsedSec = Math.max(0, Math.floor(elapsedMs / 1000))
+    let minutes = Math.floor(elapsedSec / 60)
+    let seconds = elapsedSec % 60
+    let timeStr = `${minutes}:${seconds.toString().padStart(2, '0')}`
+
+    if (elapsedSec >= COUNTDOWN_FROM_SEC && elapsedSec < MATCH_DURATION_SEC) {
+      let remaining = MATCH_DURATION_SEC - elapsedSec
+      return (
+        <p style={{ color: 'red', fontWeight: 'bold' }}>
+          Ending in {remaining}...
+        </p>
+      )
     }
 
-    onBack()
-    {
-        this.props.onBack()
-    }
+    return <p>Game Time: {timeStr}</p>
+  }
 
-    onEndMatch() {
-        this.props.onEndMatch()
-    }
+  // Render persistent colour splotches, applying fade-out during the final 3 seconds of their life
+  renderSplotches () {
+    let now = Date.now()
+    let duration = this.props.splotchDurationSec
+    let numColors = colors.length
 
-    onMouseMove(e)
-    {
-        let elem = document.querySelector(".GamePlayArea")
-        let rect = elem.getBoundingClientRect();
-        this.mousePos.x = ((e.clientX - rect.left) / 800);
-        this.mousePos.y = ((e.clientY - rect.top) / 600);
-
-        this.props.onPlayerMove(this.mousePos)
-    }
-
-    onMouseClick(e)
-    {
-        this.props.onPlayerClicked(this.mousePos, e.button)
-    }
-
-    onToggleReliable(e)
-    {
-        this.props.onToggleReliable()
-    }
-
-    onToggleOrdered(e)
-    {
-        this.props.onToggleOrdered()
-    }
-
-    onTogglePlayerMask(cxId)
-    {
-        this.props.onTogglePlayerMask(cxId)
-    }
-
-    showEndMatchButton(){
-        
-        // End match should only be optional to the lobby owner / host. The "CursorPartyGameLift" lobby type is configured to "disband on start" which means END_MATCH is not possible
-        if(this.props.lobby.ownerCxId === this.props.user.cxId && !this.props.disbandOnStart){
-            return true
+    return (this.props.splotches || [])
+      .filter(splotch => {
+        if (duration < 0) return true // forever
+        return (now - splotch.startTimeMs) / 1000 < duration
+      })
+      .map((splotch, index) => {
+        let opacity = 1.0
+        if (duration > 0) {
+          let ageSec = (now - splotch.startTimeMs) / 1000
+          let remaining = duration - ageSec
+          if (remaining <= 3) opacity = Math.max(0, remaining / 3.0)
         }
-
-        return false
-    }
-    render() {
+        let color = colors[splotch.colorIndex % numColors]
         return (
-            <div className="GameScreen" style={{ display: "flex" }}>
-                {/** Info Area */}
-                <div>
-                    {/** Players List */}
-                    <div className="OptionPanel" style={{paddingRight: 32, textAlign: "left" }}>
-                        <p>Player Mask (For shockwaves)</p>
-                        {
-                            this.props.lobby.members.map(member => (
-                                <div key={`${member.cxId}_mask`}>
-                                    <input type="checkbox" name={`${member.cxId}_mask`} onChange={() => this.onTogglePlayerMask(member.cxId)} defaultChecked={member.allowSendTo} />
-                                    {
-                                        member.isReady === true ? <label htmlFor={`${member.cxId}_mask`} style={{ color: colors[member.extra.colorIndex] }}>{member.name}</label> : <label htmlFor={`${member.cxId}_mask`} style={{ color: colors[member.extra.colorIndex] }}>{member.name + " (in lobby)"}</label>
-                                    }
-                                </div>
-                            ))
-                        }
-                    </div>
-
-                    {/** Options */}
-                    <div>
-                        <p>Reliable options (For mouse position)</p>
-                        <input type="checkbox" key="chkReliable" name="chkReliable" onChange={this.onToggleReliable.bind(this)} defaultChecked={this.props.relayOptions.reliable} />
-                        <label htmlFor="chkReliable">Reliable</label><br />
-                        <input type="checkbox" key="chkOrdered" name="chkOrdered" onChange={this.onToggleOrdered.bind(this)} defaultChecked={this.props.relayOptions.ordered} />
-                        <label htmlFor="chkOrdered">Ordered</label>
-                    </div>
-
-                    {/** Instructions */}
-                    {
-                        this.props.teams.length > 1
-                            ?
-                            <div>
-                                <p>Instructions</p>
-                                <p>Left Click = Send shockwaves to everybody</p>
-                                <p>Right Click = Send shockwaves to team mates</p>
-                                <p>Middle Click = Send shockwaves to opponents</p>
-                            </div>
-                            : ""
-                    }
-                </div>
-
-                {/** Game Side */}
-                <div>
-                    {/** Cursor Party */}
-                    <div className="GamePlayArea" style={{ cursor: `url('arrow${this.props.user.colorIndex}.png'), auto`, float: "left" }}
-                        onMouseMove={this.onMouseMove.bind(this)} onMouseDown={this.onMouseClick.bind(this)} onContextMenu={(e) => e.preventDefault()}>
-                        {
-                            this.props.shockwaves.map(shockwave => (
-                                <div key={`${shockwave.id}`} className="Entity" style={{ left: `${shockwave.pos.x - 64}px`, top: `${shockwave.pos.y - 64}px` }}>
-                                    <div className="Shockwave" style={{ backgroundColor: shockwave.color }}></div>
-                                </div>
-                            ))
-                        }
-                        {
-                            this.props.lobby.members.filter(member => member.pos && member.cxId !== this.props.user.cxId).map(member => (
-                                <div key={`${member.cxId}_arrow`} className="Entity" style={{ left: `${member.pos.x * 800}px`, top: `${member.pos.y * 600}px` }}>
-                                    <img className="Arrow" src={`arrow${member.extra.colorIndex}.png`} alt="arrow" />
-                                    <p style={{ color: colors[member.extra.colorIndex] }}>{member.name}</p>
-                                </div>
-                            ))
-                        }
-                    </div>
-                    {/** Buttons */}
-                    <div>
-                        <button className="Button" onClick={this.onBack.bind(this)}>Leave Game</button>
-                        {
-                            this.showEndMatchButton() ? <button className="Button" onClick={this.onEndMatch.bind(this)}>End Match</button> : ""
-                        }
-                    </div>
-                </div>                
-            </div>
+          <div
+            key={`splotch_${index}_${splotch.startTimeMs}`}
+            className='Entity'
+            style={{
+              left: `${splotch.x * 800 - 16}px`,
+              top: `${splotch.y * 600 - 16}px`,
+              opacity
+            }}
+          >
+            <div className='Splotch' style={{ backgroundColor: color }}></div>
+          </div>
         )
-    }
+      })
+  }
+
+  render () {
+    let numArrows = this.props.numArrowImages || 8
+    let arrowIndex = this.props.user.colorIndex % numArrows
+    let numColors = colors.length
+
+    return (
+      <div className='GameScreen' style={{ display: 'flex' }}>
+        {/** Info Area */}
+        <div>
+          {this.renderTimer()}
+
+          {/** Players List / Mask */}
+          <div
+            className='OptionPanel'
+            style={{ paddingRight: 32, textAlign: 'left' }}
+          >
+            <p>Player Mask (For splotches)</p>
+            {this.props.lobby.members.map(member => (
+              <div key={`${member.cxId}_mask`}>
+                <input
+                  type='checkbox'
+                  name={`${member.cxId}_mask`}
+                  onChange={() => this.onTogglePlayerMask(member.cxId)}
+                  defaultChecked={member.allowSendTo}
+                />
+                <label
+                  htmlFor={`${member.cxId}_mask`}
+                  style={{ color: colors[member.extra.colorIndex % numColors] }}
+                >
+                  {member.isReady ? member.name : member.name + ' (in lobby)'}
+                </label>
+              </div>
+            ))}
+          </div>
+
+          {/** Reliable/Ordered Options */}
+          <div>
+            <p>Reliable options (For mouse position)</p>
+            <input
+              type='checkbox'
+              key='chkReliable'
+              name='chkReliable'
+              onChange={this.onToggleReliable.bind(this)}
+              defaultChecked={this.props.relayOptions.reliable}
+            />
+            <label htmlFor='chkReliable'>Reliable</label>
+            <br />
+            <input
+              type='checkbox'
+              key='chkOrdered'
+              name='chkOrdered'
+              onChange={this.onToggleOrdered.bind(this)}
+              defaultChecked={this.props.relayOptions.ordered}
+            />
+            <label htmlFor='chkOrdered'>Ordered</label>
+          </div>
+
+          {/** Team Instructions */}
+          {this.props.teams.length > 1 ? (
+            <div>
+              <p>Instructions</p>
+              <p>Left Click = Splotch everybody</p>
+              <p>Right Click = Splotch team mates</p>
+              <p>Middle Click = Splotch opponents</p>
+            </div>
+          ) : (
+            ''
+          )}
+        </div>
+
+        {/** Game Canvas */}
+        <div>
+          <div
+            className='GamePlayArea'
+            style={{
+              cursor: `url('arrow${arrowIndex}.png'), auto`,
+              float: 'left'
+            }}
+            onMouseMove={this.onMouseMove.bind(this)}
+            onMouseDown={this.onMouseClick.bind(this)}
+            onContextMenu={e => e.preventDefault()}
+          >
+            {/** Transient shockwave rings */}
+            {(this.props.shockwaves || []).map(shockwave => (
+              <div key={shockwave.id} className='Entity'
+                style={{ left: `${shockwave.pos.x - 64}px`, top: `${shockwave.pos.y - 64}px` }}>
+                <div className='Shockwave' style={{ backgroundColor: shockwave.color }} />
+              </div>
+            ))}
+
+            {/** Persistent splotches */}
+            {this.renderSplotches()}
+
+            {/** Other players' cursors */}
+            {this.props.lobby.members
+              .filter(
+                member => member.pos && member.cxId !== this.props.user.cxId
+              )
+              .map(member => (
+                <div
+                  key={`${member.cxId}_arrow`}
+                  className='Entity'
+                  style={{
+                    left: `${member.pos.x * 800}px`,
+                    top: `${member.pos.y * 600}px`
+                  }}
+                >
+                  <img
+                    className='Arrow'
+                    src={`arrow${member.extra.colorIndex % numArrows}.png`}
+                    alt='arrow'
+                  />
+                  <p
+                    style={{
+                      color: colors[member.extra.colorIndex % numColors]
+                    }}
+                  >
+                    {member.name}
+                  </p>
+                </div>
+              ))}
+          </div>
+
+          {/** Buttons */}
+          <div>
+            <button className='Button' onClick={this.onBack.bind(this)}>
+              Leave Game
+            </button>
+            {this.showEndMatchButton() ? (
+              <button className='Button' onClick={this.onEndMatch.bind(this)}>
+                End Match
+              </button>
+            ) : (
+              ''
+            )}
+            {this.showClearSplotchesButton() ? (
+              <button
+                className='Button'
+                onClick={this.onClearSplotches.bind(this)}
+              >
+                Clear Splotches
+              </button>
+            ) : (
+              ''
+            )}
+          </div>
+        </div>
+      </div>
+    )
+  }
 }
 
-export default GameScreen;
+export default GameScreen

--- a/RelayTestApp/src/LoadingScreen.js
+++ b/RelayTestApp/src/LoadingScreen.js
@@ -1,34 +1,70 @@
 import React, { Component } from 'react'
 
 // Props:
-//  text
-class LoadingScreen extends Component
-{
-    onBack()
-    {
-        this.props.onBack()
+//  text        — primary message
+//  statusText  — secondary status line (e.g. "Provisioning server...")
+//  lobbyId     — shown when available
+//  startTime   — Date.now() timestamp, drives the elapsed timer
+//  onBack      — if provided, shows a Cancel button
+class LoadingScreen extends Component {
+  componentDidMount () {
+    if (this.props.startTime) {
+      this.timerInterval = setInterval(() => this.forceUpdate(), 1000)
     }
+  }
 
-    render()
-    {
-        if (this.props.onBack)
-        {
-            return (
-                <div className="LoadingScreen">
-                    <p>{this.props.text}</p>
-                    <button className="Button" onClick={this.onBack.bind(this)}>Cancel</button>
-                </div>
-            )
-        }
-        else
-        {
-            return (
-                <div className="LoadingScreen">
-                    <p>{this.props.text}</p>
-                </div>
-            )
-        }
-    }
+  componentWillUnmount () {
+    clearInterval(this.timerInterval)
+  }
+
+  renderTimer () {
+    if (!this.props.startTime) return null
+    let elapsedSec = Math.max(
+      0,
+      Math.floor((Date.now() - this.props.startTime) / 1000)
+    )
+    let minutes = Math.floor(elapsedSec / 60)
+    let seconds = elapsedSec % 60
+    let timeStr = `${minutes}:${seconds.toString().padStart(2, '0')}`
+
+    // Warn after 60 seconds — a new server may be warming up
+    let isLong = elapsedSec >= 60
+    return (
+      <p
+        style={{
+          color: isLong ? '#ffcc44' : 'white',
+          fontWeight: isLong ? 'bold' : 'normal'
+        }}
+      >
+        {timeStr}
+        {isLong ? ' — server may be warming up...' : ''}
+      </p>
+    )
+  }
+
+  render () {
+    return (
+      <div className='LoadingScreen'>
+        <p>{this.props.text}</p>
+        {this.renderTimer()}
+        {this.props.statusText ? (
+          <p style={{ opacity: 0.65, fontSize: '10pt' }}>
+            {this.props.statusText}
+          </p>
+        ) : null}
+        {this.props.lobbyId ? (
+          <p style={{ opacity: 0.45, fontSize: '9pt' }}>
+            Lobby: {this.props.lobbyId}
+          </p>
+        ) : null}
+        {this.props.onBack ? (
+          <button className='Button' onClick={this.props.onBack.bind(this)}>
+            Cancel
+          </button>
+        ) : null}
+      </div>
+    )
+  }
 }
 
-export default LoadingScreen;
+export default LoadingScreen

--- a/RelayTestApp/src/LobbyScreen.js
+++ b/RelayTestApp/src/LobbyScreen.js
@@ -8,76 +8,130 @@ let colors = require('./Colors').colors
 // user
 // lobby
 class LobbyScreen extends Component {
-    onBack() {
-        this.props.onBack()
+  onBack () {
+    this.props.onBack()
+  }
+
+  onStart () {
+    this.props.onStart()
+  }
+
+  onJoin () {
+    this.props.onJoin()
+  }
+
+  onColorSelected (index) {
+    this.props.user.colorIndex = index
+    let me = this.props.lobby.members.find(
+      member => member.cxId === this.props.user.cxId
+    )
+    if (me) {
+      me.extra.colorIndex = index
     }
+    localStorage.setItem('color', '' + index)
+    this.props.onColorChanged(index)
+  }
 
-    onStart() {
-        this.props.onStart()
-    }
+  onTeamSelected (teamName) {
+    console.log('User trying to join team ' + teamName)
+    this.props.onTeamChanged(teamName)
+  }
 
-    onJoin() {
-        this.props.onJoin()
-    }
-
-    onColorSelected(index) {
-        this.props.user.colorIndex = index
-        let me = this.props.lobby.members.find(member => member.cxId === this.props.user.cxId)
-        if (me) {
-            me.extra.colorIndex = index
-        }
-        localStorage.setItem("color", "" + index)
-        this.props.onColorChanged(index)
-    }
-
-    onTeamSelected(teamName){
-        console.log("User trying to join team " + teamName)
-        this.props.onTeamChanged(teamName)
-    }
-
-    render() {
-        return (
-            <div className="LobbyScreen">
-                <div>
-                    {
-                        /** If there are no teams, users can select their own colour. Otherwise, colour will initially be assigned automatically by team. */
-                        this.props.teams.length === 1 ?
-                            colors.map((color, i) => (<div key={color} className="colorBtn" style={{ backgroundColor: color, display: "inline-block", width: "50px", height: "40px" }} onClick={this.onColorSelected.bind(this, i)}>{i}</div>)) :
-                            ""
-                    }
-                </div>
-                <div style={{display: "flex", justifyContent:"space-between"}}>
-                    {
-                        this.props.teams.map((team, index) => (
-                            <div key={team.name}>
-                                {
-                                    this.props.teams.length > 1 ? <button key={index} className="teamBtn" onClick={this.onTeamSelected.bind(this, team.name)}>Join Team {team.name}</button> : ""
-                                }
-                                <ul>
-                                    {
-                                        team.members.map(member => (
-                                            member.cxId === this.props.lobby.ownerCxId ? <li key={member.cxId} style={{ color: colors[member.extra.colorIndex] }}>{member.name + " (host)"}</li> : <li key={member.cxId} style={{ color: colors[member.extra.colorIndex] }}>{member.name}</li>
-                                        ))
-                                    }
-                                </ul>
-                            </div>
-                        ))
-                    }
-                </div>        
-                <div style={{ display: "flex", justifyContent: "center" }}>
-                    {
-                        this.props.lobby.ownerCxId === this.props.user.cxId && !this.props.user.isReady ? <button className="Button" onClick={this.onStart.bind(this)}>Start</button> : ""
-                    }
-                    {
-                        getShowJoinButton() ? <button className="Button" onClick={this.onJoin.bind(this)}>Join Match</button> : ""
-                    }
-                    <button className="Button" onClick={this.onBack.bind(this)}>Leave</button>
-
-                </div>
-                <p>Lobby ID: {this.props.lobby.lobbyId}</p>
+  render () {
+    return (
+      <div className='LobbyScreen'>
+        <div>
+          {
+            /** If there are no teams, users can select their own colour. Otherwise, colour will initially be assigned automatically by team. */
+            this.props.teams.length === 1 ? (
+              <div
+                style={{
+                  display: 'flex',
+                  flexWrap: 'wrap',
+                  maxWidth: '360px',
+                  justifyContent: 'flex-start'
+                }}
+              >
+                {colors.map((color, i) => (
+                  <div
+                    key={color + i}
+                    className='colorBtn'
+                    style={{
+                      backgroundColor: color,
+                      display: 'inline-block',
+                      width: '28px',
+                      height: '24px'
+                    }}
+                    onClick={this.onColorSelected.bind(this, i)}
+                    title={i}
+                  />
+                ))}
+              </div>
+            ) : (
+              ''
+            )
+          }
+        </div>
+        <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+          {this.props.teams.map((team, index) => (
+            <div key={team.name}>
+              {this.props.teams.length > 1 ? (
+                <button
+                  key={index}
+                  className='teamBtn'
+                  onClick={this.onTeamSelected.bind(this, team.name)}
+                >
+                  Join Team {team.name}
+                </button>
+              ) : (
+                ''
+              )}
+              <ul>
+                {team.members.map(member =>
+                  member.cxId === this.props.lobby.ownerCxId ? (
+                    <li
+                      key={member.cxId}
+                      style={{ color: colors[member.extra.colorIndex] }}
+                    >
+                      {member.name + ' (host)'}
+                    </li>
+                  ) : (
+                    <li
+                      key={member.cxId}
+                      style={{ color: colors[member.extra.colorIndex] }}
+                    >
+                      {member.name}
+                    </li>
+                  )
+                )}
+              </ul>
             </div>
-        )
-    }
+          ))}
+        </div>
+        <div style={{ display: 'flex', justifyContent: 'center' }}>
+          <button className='Button' onClick={this.onBack.bind(this)}>
+            Leave
+          </button>
+          {this.props.lobby.ownerCxId === this.props.user.cxId &&
+          !this.props.user.isReady ? (
+            <button className='Button' onClick={this.onStart.bind(this)}>
+              Start
+            </button>
+          ) : (
+            ''
+          )}
+          {getShowJoinButton() ? (
+            <button className='Button' onClick={this.onJoin.bind(this)}>
+              Join Match
+            </button>
+          ) : (
+            ''
+          )}
+        </div>
+        <p>Lobby ID: {this.props.lobby.lobbyId}</p>
+      </div>
+    )
+  }
 }
 
-export default LobbyScreen;
+export default LobbyScreen

--- a/RelayTestApp/src/LobbyScreen.js
+++ b/RelayTestApp/src/LobbyScreen.js
@@ -114,7 +114,11 @@ class LobbyScreen extends Component {
           </button>
           {this.props.lobby.ownerCxId === this.props.user.cxId &&
           !this.props.user.isReady ? (
-            <button className='Button' onClick={this.onStart.bind(this)}>
+            <button
+              className='Button'
+              onClick={this.onStart.bind(this)}
+              disabled={this.props.lobbyResetting}
+            >
               Start
             </button>
           ) : (


### PR DESCRIPTION
… Persistence  - My auto format attacked these files on save

Changes made
Colors.js

Expanded from 8 → 40 colours matching the C++ palette (4 tonal rows: vivid, vivid-medium, pastel, muted) App.js
Colour picker now displays all 40 colours in a wrapped flex grid (28×24px swatches, colour index shown on hover via title) App.css

Renamed "Relay Server Test App" → "Cursor Party" everywhere State: add splotches, added gameStartTime, splotchDurationSec, round SplotchDuration global property: read from brainCloud on login (default -1 = forever) Game timer: host sets gameStartTime = Date.now() on relay connect, broadcasts game_start to all; non-owners receive it via relay message Auto-end: host schedules setTimeout at 90 seconds → calls onEndMatch() Persistent splotches: createSplotch() stores {x, y, colorIndex, startTimeMs} in state instead of expiring after 1s JIP sync: on CONNECT system message, host sends sendGameStartToMask() + sendSplotchSyncToMask() (chunked, max 900 bytes/packet) to the new player Relay messages: handles game_start, splotch_sync, clear_splotches in addition to move/shockwave Clear Splotches: onClearSplotches() broadcasts clear_splotches to all players Team colours: alpha → index 6 (sky blue), beta → index 0 (vivid red) Version info: displays v1.0 | App: <id> | Server: <env> on login/main menu (BCLOUD-8526) GameScreen.js

Game timer: setInterval re-renders every second; shows MM:SS, switches to red countdown in final 10 seconds Splotch rendering: filters by age vs splotchDurationSec, fades out during last 3 seconds of life Clear Splotches button: visible to host only
Arrow images: uses colorIndex % 8 to stay within the 8 available arrow image files LobbyScreen.js

Added .Splotch class: 32×32px solid circle